### PR TITLE
Group languages by locale so you can easily browse them

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.formatOnSave": false
-}

--- a/browser/dasher/controlpanel.js
+++ b/browser/dasher/controlpanel.js
@@ -15,7 +15,7 @@ class Control {
         this._node = undefined;
         this._valueListener = null;
         this._addedListener = null;
-        this._optionGroups = undefined;
+        this._optionList = undefined;
         this._active = undefined;
 
         this._selectedIndex = undefined;
@@ -104,30 +104,24 @@ class Control {
         this.active = !!this.active;
 
         // If option strings were set early, create <option> elements now.
-        if (this.optionGroups !== undefined) {
-            // Loop through each group
-            for (let [key, values] of Object.entries(optionGroups)) {
-                // 'root' is the magic key that puts its values in the root of the select
-                if(key === 'root') {
-                    values.forEach(optionString => {
-                        this.node.add(
-                            new Option(optionString)
+        if (this.optionList !== undefined) {
+
+            this.optionList.forEach(option => {
+                if(typeof option === 'string') {
+                    this.node.add(
+                        new Option(option)
+                    );
+                } else {
+                    const optGroup = document.createElement('optgroup');
+                    optGroup.label = option.label;
+                    option.values.forEach(current => {
+                        optGroup.append(
+                            new Option(current)
                         );
                     })
-                // Otherwise it's a group of options
-                } else {
-                    const optGroup = document.createElement("optgroup");
-                    optGroup.label = key;
-
-                    values.forEach(optionString => {
-                        optGroup.append(
-                            new Option(optionString)
-                        );
-                    });
-
-                    this.node.add(optGroup);
+                    this.node.add(optGroup)
                 }
-            }
+            })
         }
 
         this.select_option(
@@ -231,11 +225,11 @@ class Control {
         this.node.addEventListener(this._listenerType, this._addedListener);
     }
 
-    get optionGroups() {return this._optionGroups;}
-    set optionGroups(optionGroups) {
+    get optionList() {return this._optionList;}
+    set optionList(optionList) {
         // Only works with control:select instances.
 
-        this._optionGroups = optionGroups;
+        this._optionList = optionList;
 
         if (this.node !== null && this.node.selectedIndex !== -1) {
             // Get the current value and preserve it in case the new options
@@ -248,29 +242,26 @@ class Control {
             this.piece.remove_all();
         }
         if (this.node !== null) {
-            // Loop through each group
-            for (let [key, values] of Object.entries(optionGroups)) {
-                // 'root' is the magic key that puts its values in the root of the select
-                if(key === 'root') {
-                    values.forEach(optionString => {
-                        this.node.add(
-                            new Option(optionString)
+
+            optionList.forEach(option => {
+                if(typeof option === 'string') {
+                    this.node.add(
+                        new Option(option)
+                    );
+                } else {
+                    const optGroup = document.createElement('optgroup');
+                    optGroup.label = option.label;
+                    option.values.forEach(current => {
+                        optGroup.append(
+                            new Option(current)
                         );
                     })
-                // Otherwise it's a group of options
-                } else {
-                    const optGroup = document.createElement("optgroup");
-                    optGroup.label = key;
-
-                    values.forEach(optionString => {
-                        optGroup.append(
-                            new Option(optionString)
-                        );
-                    });
-
-                    this.node.add(optGroup);
+                    this.node.add(optGroup)
                 }
-            }
+            })
+        
+
+            
         }
         this.select_option(this._selectedString, this._selectedIndex);
 
@@ -334,10 +325,17 @@ class Control {
     }
 
     select_option(selectedString, selectedIndex) {
-        const allOptionStrings = Object.values((this._optionGroups || {})).flat();
+        const tempOptionList = this._optionList || [];
+        const allOptionStrings = tempOptionList.map(current => {
+            if(typeof current === 'string') {
+                return current;
+            }
+
+            return current.values;
+       })
 
         const foundIndex = (
-            (selectedString === undefined || this._optionGroups === undefined)
+            (selectedString === undefined || this._optionList === undefined)
             ? -1 : allOptionStrings.indexOf(selectedString));
 
         if (foundIndex === -1) {

--- a/browser/dasher/controlpanel.js
+++ b/browser/dasher/controlpanel.js
@@ -15,7 +15,7 @@ class Control {
         this._node = undefined;
         this._valueListener = null;
         this._addedListener = null;
-        this._optionStrings = undefined;
+        this._optionGroups = undefined;
         this._active = undefined;
 
         this._selectedIndex = undefined;
@@ -104,10 +104,30 @@ class Control {
         this.active = !!this.active;
 
         // If option strings were set early, create <option> elements now.
-        if (this.optionStrings !== undefined) {
-            this.optionStrings.forEach(optionString => this.node.add(
-                new Option(optionString)
-            ));
+        if (this.optionGroups !== undefined) {
+            // Loop through each group
+            for (let [key, values] of Object.entries(optionGroups)) {
+                // 'root' is the magic key that puts its values in the root of the select
+                if(key === 'root') {
+                    values.forEach(optionString => {
+                        this.node.add(
+                            new Option(optionString)
+                        );
+                    })
+                // Otherwise it's a group of options
+                } else {
+                    const optGroup = document.createElement("optgroup");
+                    optGroup.label = key;
+
+                    values.forEach(optionString => {
+                        optGroup.append(
+                            new Option(optionString)
+                        );
+                    });
+
+                    this.node.add(optGroup);
+                }
+            }
         }
 
         this.select_option(
@@ -211,11 +231,11 @@ class Control {
         this.node.addEventListener(this._listenerType, this._addedListener);
     }
 
-    get optionStrings() {return this._optionStrings;}
-    set optionStrings(optionStrings) {
+    get optionGroups() {return this._optionGroups;}
+    set optionGroups(optionGroups) {
         // Only works with control:select instances.
 
-        this._optionStrings = optionStrings.slice();
+        this._optionGroups = optionGroups;
 
         if (this.node !== null && this.node.selectedIndex !== -1) {
             // Get the current value and preserve it in case the new options
@@ -228,8 +248,29 @@ class Control {
             this.piece.remove_all();
         }
         if (this.node !== null) {
-            this._optionStrings.forEach(optionString => this.node.add(
-                new Option(optionString)));
+            // Loop through each group
+            for (let [key, values] of Object.entries(optionGroups)) {
+                // 'root' is the magic key that puts its values in the root of the select
+                if(key === 'root') {
+                    values.forEach(optionString => {
+                        this.node.add(
+                            new Option(optionString)
+                        );
+                    })
+                // Otherwise it's a group of options
+                } else {
+                    const optGroup = document.createElement("optgroup");
+                    optGroup.label = key;
+
+                    values.forEach(optionString => {
+                        optGroup.append(
+                            new Option(optionString)
+                        );
+                    });
+
+                    this.node.add(optGroup);
+                }
+            }
         }
         this.select_option(this._selectedString, this._selectedIndex);
 
@@ -293,9 +334,11 @@ class Control {
     }
 
     select_option(selectedString, selectedIndex) {
+        const allOptionStrings = Object.values((this._optionGroups || {})).flat();
+
         const foundIndex = (
-            (selectedString === undefined || this._optionStrings === undefined)
-            ? -1 : this._optionStrings.indexOf(selectedString));
+            (selectedString === undefined || this._optionGroups === undefined)
+            ? -1 : allOptionStrings.indexOf(selectedString));
 
         if (foundIndex === -1) {
             this._selectedIndex = selectedIndex;

--- a/browser/dasher/controlpanel.js
+++ b/browser/dasher/controlpanel.js
@@ -105,12 +105,14 @@ class Control {
 
         // If option strings were set early, create <option> elements now.
         if (this.optionList !== undefined) {
-
             this.optionList.forEach(option => {
+                // If the current option is a string we add that directly
                 if(typeof option === 'string') {
                     this.node.add(
                         new Option(option)
                     );
+                // If its not a string we assume its an object in the shape:
+                // { label: "Group Label", values: ['first', 'second'] }
                 } else {
                     const optGroup = document.createElement('optgroup');
                     optGroup.label = option.label;
@@ -244,10 +246,13 @@ class Control {
         if (this.node !== null) {
 
             optionList.forEach(option => {
+                // If the current option is a string we add that directly
                 if(typeof option === 'string') {
                     this.node.add(
                         new Option(option)
                     );
+                // If its not a string we assume its an object in the shape:
+                // { label: "Group Label", values: ['first', 'second'] }
                 } else {
                     const optGroup = document.createElement('optgroup');
                     optGroup.label = option.label;
@@ -325,6 +330,7 @@ class Control {
     }
 
     select_option(selectedString, selectedIndex) {
+        // Get a flattened list of all the options
         const tempOptionList = this._optionList || [];
         const allOptionStrings = tempOptionList.map(current => {
             if(typeof current === 'string') {
@@ -332,7 +338,7 @@ class Control {
             }
 
             return current.values;
-       })
+       }).flat();
 
         const foundIndex = (
             (selectedString === undefined || this._optionList === undefined)

--- a/browser/dasher/userinterface.js
+++ b/browser/dasher/userinterface.js
@@ -281,7 +281,7 @@ export default class UserInterface {
 
                 let voiceGroups = [];
                 speech.voices.forEach(voice => {
-                    const currentLangGroup = voiceGroups.find(x => x.label == voice.lang);
+                    const currentLangGroup = voiceGroups.find(x => x.label === voice.lang);
 
                     if(currentLangGroup === undefined) {
                         voiceGroups.push({
@@ -297,12 +297,13 @@ export default class UserInterface {
                 // principle but the voice list is empty. This happened to Jim
                 // with Chromium browser for Linux. See also:
                 // https://github.com/dasher-project/dasher-web/issues/101
-                this._panels.speech.voice.optionList = (
-                    voiceGroups.length > 0 ? voiceGroups :
-                    voiceGroups.length < 0
-                        ? [`Voices available: ${voiceGroups.length}.`]
-                        : ['No voices available.']
-                );
+                this._panels.speech.voice.optionList =
+                    (voiceGroups.length > 0) ? voiceGroups
+                    : voiceGroups.length === 0 ? ['No voices available.']
+                    : [`Voices available: ${voiceGroups.length}.`]
+                ;
+                // There's no way that voiceGroups.length should anything other
+                // than zero or a positive number but just in case.
             }
             else {
                 this._panels.speech.voice.optionList = ['Speech unavailable'];

--- a/browser/dasher/userinterface.js
+++ b/browser/dasher/userinterface.js
@@ -1,4 +1,4 @@
-// (c) 2020 The ACE Centre-North, UK registered charity 1089313.
+// (c) 2021 The ACE Centre-North, UK registered charity 1089313.
 // MIT licensed, see https://opensource.org/licenses/MIT
 
 /*

--- a/browser/dasher/userinterface.js
+++ b/browser/dasher/userinterface.js
@@ -276,11 +276,6 @@ export default class UserInterface {
 
         new Speech().initialise(speech => {
             this._speech = speech;
-
-            // To Do: Probably disable everything if !speech.available. Maybe
-            // add convenience methods to Control to: hide the control. Hiding
-            // could work by removing it from its parent ...
-
             this._panels.speech.stop.active = speech.available;
             if (speech.available) {
 
@@ -294,12 +289,20 @@ export default class UserInterface {
                             values: [voice.name]
                         });
                     } else {
-                        currentLangGroup.values.push(voice.name)
+                        currentLangGroup.values.push(voice.name);
                     }
                 })
-              
-                // Convert object to a list
-                this._panels.speech.voice.optionList = voiceGroups;
+
+                // So, funny thing is that sometimes speech is available in
+                // principle but the voice list is empty. This happened to Jim
+                // with Chromium browser for Linux. See also:
+                // https://github.com/dasher-project/dasher-web/issues/101
+                this._panels.speech.voice.optionList = (
+                    voiceGroups.length > 0 ? voiceGroups :
+                    voiceGroups.length < 0
+                        ? [`Voices available: ${voiceGroups.length}.`]
+                        : ['No voices available.']
+                );
             }
             else {
                 this._panels.speech.voice.optionList = ['Speech unavailable'];

--- a/browser/dasher/userinterface.js
+++ b/browser/dasher/userinterface.js
@@ -150,10 +150,8 @@ export default class UserInterface {
     }
     set predictors(predictors) {
         this._predictors = predictors.slice();
-        const predictorLabels = this.predictors.map(predictor => predictor.label)
-        this._panels.main.prediction.optionGroups = {
-            root: predictorLabels
-        }
+        this._panels.main.prediction.optionList = this.predictors.map(
+            predictor => predictor.label);
     }
 
     load(loadingID, footerID) {
@@ -235,7 +233,7 @@ export default class UserInterface {
             this._controllerPointer.predictor = this.predictors[index].item;
         };
 
-        this._panels.main.behaviour.optionGroups = { root: ["A","B"]};
+        this._panels.main.behaviour.optionList = ["A","B"];
         this._panels.main.behaviour.listener = index => this._select_behaviour(
             index);
 
@@ -286,23 +284,25 @@ export default class UserInterface {
             this._panels.speech.stop.active = speech.available;
             if (speech.available) {
                 let voiceGroups = {};
-              
-                for (let i = 0; i < speech.voices.length; i++) {
-                    const currentVoice = speech.voices[i];
-              
-                    if (voiceGroups[currentVoice.lang] === undefined) {
-                        voiceGroups[currentVoice.lang] = [currentVoice.name];
-                    } else {
-                        voiceGroups[currentVoice.lang].push(currentVoice.name);
+
+                speech.voices.forEach(voice => {
+
+                    // Create a group for each voice.
+                    if (voiceGroups[voice.lang] === undefined) {
+                        voiceGroups[voice.lang] = [];
                     }
-                }
+                    voiceGroups[voice.lang].push(voice.name);
+                })
               
-                this._panels.speech.voice.optionGroups = voiceGroups;
+                this._panels.speech.voice.optionList = Object.entries(voiceGroups).map(([lang, voices]) => {
+                    return {
+                        label: lang,
+                        values: voices
+                    };
+                });
             }
             else {
-                this._panels.speech.voice.optionGroups = {
-                    root: ['Speech unavailable']
-                };
+                this._panels.speech.voice.optionList = ['Speech unavailable'];
             }
         });
     }

--- a/browser/dasher/userinterface.js
+++ b/browser/dasher/userinterface.js
@@ -283,23 +283,23 @@ export default class UserInterface {
 
             this._panels.speech.stop.active = speech.available;
             if (speech.available) {
-                let voiceGroups = {};
 
+                let voiceGroups = [];
                 speech.voices.forEach(voice => {
+                    const currentLangGroup = voiceGroups.find(x => x.label == voice.lang);
 
-                    // Create a group for each voice.
-                    if (voiceGroups[voice.lang] === undefined) {
-                        voiceGroups[voice.lang] = [];
+                    if(currentLangGroup === undefined) {
+                        voiceGroups.push({
+                            label: voice.lang,
+                            values: [voice.name]
+                        });
+                    } else {
+                        currentLangGroup.values.push(voice.name)
                     }
-                    voiceGroups[voice.lang].push(voice.name);
                 })
               
-                this._panels.speech.voice.optionList = Object.entries(voiceGroups).map(([lang, voices]) => {
-                    return {
-                        label: lang,
-                        values: voices
-                    };
-                });
+                // Convert object to a list
+                this._panels.speech.voice.optionList = voiceGroups;
             }
             else {
                 this._panels.speech.voice.optionList = ['Speech unavailable'];

--- a/browser/dasher/userinterface.js
+++ b/browser/dasher/userinterface.js
@@ -150,8 +150,10 @@ export default class UserInterface {
     }
     set predictors(predictors) {
         this._predictors = predictors.slice();
-        this._panels.main.prediction.optionStrings = this.predictors.map(
-            predictor => predictor.label);
+        const predictorLabels = this.predictors.map(predictor => predictor.label)
+        this._panels.main.prediction.optionGroups = {
+            root: predictorLabels
+        }
     }
 
     load(loadingID, footerID) {
@@ -233,7 +235,7 @@ export default class UserInterface {
             this._controllerPointer.predictor = this.predictors[index].item;
         };
 
-        this._panels.main.behaviour.optionStrings = ["A","B"];
+        this._panels.main.behaviour.optionGroups = { root: ["A","B"]};
         this._panels.main.behaviour.listener = index => this._select_behaviour(
             index);
 
@@ -283,12 +285,24 @@ export default class UserInterface {
 
             this._panels.speech.stop.active = speech.available;
             if (speech.available) {
-                this._panels.speech.voice.optionStrings = speech.voices.map(
-                    voice => `${voice.name} (${voice.lang})`);
+                let voiceGroups = {};
+              
+                for (let i = 0; i < speech.voices.length; i++) {
+                    const currentVoice = speech.voices[i];
+              
+                    if (voiceGroups[currentVoice.lang] === undefined) {
+                        voiceGroups[currentVoice.lang] = [currentVoice.name];
+                    } else {
+                        voiceGroups[currentVoice.lang].push(currentVoice.name);
+                    }
+                }
+              
+                this._panels.speech.voice.optionGroups = voiceGroups;
             }
             else {
-                this._panels.speech.voice.optionStrings = [
-                    'Speech unavailable'];
+                this._panels.speech.voice.optionGroups = {
+                    root: ['Speech unavailable']
+                };
             }
         });
     }


### PR DESCRIPTION
Fix for #31 

Ideally it would show language rather than locale so its more understandable. However, there is no native way to get that information. The lang codes are strictly defined so you could pull a map of lang codes to languages fairly easily but it just seems like unnecessary data to send to the client.

<img width="353" alt="Screenshot 2021-07-15 at 16 53 59" src="https://user-images.githubusercontent.com/1359202/125818576-ed7256ef-2864-4ba5-bd04-20320abbb0c0.png">

I had to restructure the options to code to group grouping to work. Options now takes an object rather than an array. Each key is a group and each value in the object should be a list of values for the group.

There is a magic key of 'root' if you want to have a totally flat list.
